### PR TITLE
Fix null reference exception when running under Mono

### DIFF
--- a/AsyncRewriter/RewriteAsync.cs
+++ b/AsyncRewriter/RewriteAsync.cs
@@ -25,7 +25,7 @@ namespace AsyncRewriter
 
         public RewriteAsync()
         {
-            _rewriter = new Rewriter(new TaskLoggingAdapter(Log));
+            _rewriter = Log == null ? new Rewriter() : new Rewriter(new TaskLoggingAdapter(Log));
         }
 
         public override bool Execute()


### PR DESCRIPTION
When running under Mono, Log property is null and then, Rewriter throws NullReferenceExceptions when trying to use the underlying Log. 

When Log is null, use the default Rewriter constructor which uses a Console logger.

@roji , I tested this patch and it worked ok. It allowed me to compile Npgsql develop branch with Xamarin Studio on OSX. 
