### PR TITLE
use dnxcore50 moniker

### DIFF
--- a/src/AsyncRewriter/project.json
+++ b/src/AsyncRewriter/project.json
@@ -36,7 +36,7 @@
         "Microsoft.Extensions.FileSystemGlobbing": "1.0.0-*"
       }
     },
-    "dotnet54": {
+    "dnxcore50": {
       "dependencies": {
         "System.Console": "4.0.0-*",
         "System.Data.Common": "4.0.1-*",


### PR DESCRIPTION
@roji while pulled as a build dependency in ngpsql, rewriter is invoked with DNX. For that reason, it has to use the dnx moniker to work.
